### PR TITLE
Fix when clustering with dim specified

### DIFF
--- a/assignment3/requirements.txt
+++ b/assignment3/requirements.txt
@@ -2,6 +2,7 @@ numpy == 1.15.1
 scipy == 1.1.0
 scikit-learn == 0.20.0
 pandas == 0.23.4
+tables == 3.4.4
 xlrd == 0.9.0
 matplotlib == 2.2.3
 seaborn == 0.9.0


### PR DESCRIPTION
Was receiving error says `import tables` failed due to no existing module. Doing research I found that the `tables` module is an optional install via `pandas`. Adding the install to the requirements fixed this for me.