### PR TITLE
read_and_plot_acc not plotting accuracy

### DIFF
--- a/assignment3/experiments/plotting.py
+++ b/assignment3/experiments/plotting.py
@@ -544,7 +544,7 @@ def read_and_plot_acc(problem, file, output_dir):
 
     title = '{} - {}: Accuracy vs Number of Clusters'.format(ds_readable_name, problem['name'])
     df = pd.read_csv(file).set_index('k')
-    p = plot_sse(title, df)
+    p = plot_acc(title, df)
     p = watermark(p)
     p.savefig(
         '{}/{}/{}_acc.png'.format(output_dir, problem['name'], ds_name),


### PR DESCRIPTION
The `read_and_plot_acc` method is plotting `sse`, not `acc`. This change fixes that.